### PR TITLE
stow the created template on the parser

### DIFF
--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -29,6 +29,7 @@ class Parser {
 
   Lexer lexer;
   TemplateStorage& template_storage;
+  std::vector<Template> template_stash;
   const FunctionStorage& function_storage;
 
   Token tok, peek_tok;
@@ -622,7 +623,7 @@ public:
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
   Template parse(std::string_view input, std::string_view path) {
-    auto result = Template(static_cast<std::string>(input));
+    auto& result = template_stash.emplace_back(Template(static_cast<std::string>(input)));
     parse_into(result, path);
     return result;
   }

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -1467,6 +1467,7 @@ class Parser {
 
   Lexer lexer;
   TemplateStorage& template_storage;
+  std::vector<Template> template_stash;
   const FunctionStorage& function_storage;
 
   Token tok, peek_tok;
@@ -2060,7 +2061,7 @@ public:
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
   Template parse(std::string_view input, std::string_view path) {
-    auto result = Template(static_cast<std::string>(input));
+    auto& result = template_stash.emplace_back(Template(static_cast<std::string>(input)));
     parse_into(result, path);
     return result;
   }


### PR DESCRIPTION
The variable `result` was a dangling reference when returning from `Parser::parse` function, so we stash the template on the `Parser` and use a reference to that object instead. 