### PR TITLE
fix dangling reference in parser::Parse with unique_ptr

### DIFF
--- a/include/inja/environment.hpp
+++ b/include/inja/environment.hpp
@@ -105,7 +105,7 @@ public:
 
   Template parse(std::string_view input) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
-    return parser.parse(input, input_path);
+    return *parser.parse(input, input_path);
   }
 
   Template parse_template(const std::string& filename) {

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -621,8 +621,8 @@ public:
                   const FunctionStorage& function_storage)
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
-  std::shared_ptr<Template> parse(std::string_view input, std::string_view path) {
-    auto result = std::make_shared<Template>(static_cast<std::string>(input));
+  std::unique_ptr<Template> parse(std::string_view input, std::string_view path) {
+    auto result = std::make_unique<Template>(static_cast<std::string>(input));
     parse_into(*result, path);
     return result;
   }

--- a/include/inja/parser.hpp
+++ b/include/inja/parser.hpp
@@ -621,9 +621,9 @@ public:
                   const FunctionStorage& function_storage)
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
-  Template parse(std::string_view input, std::string_view path) {
-    auto result = Template(static_cast<std::string>(input));
-    parse_into(result, path);
+  std::shared_ptr<Template> parse(std::string_view input, std::string_view path) {
+    auto result = std::make_shared<Template>(static_cast<std::string>(input));
+    parse_into(*result, path);
     return result;
   }
 

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2059,8 +2059,8 @@ public:
                   const FunctionStorage& function_storage)
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
-  std::shared_ptr<Template> parse(std::string_view input, std::string_view path) {
-    auto result = std::make_shared<Template>(static_cast<std::string>(input));
+  std::unique_ptr<Template> parse(std::string_view input, std::string_view path) {
+    auto result = std::make_unique<Template>(static_cast<std::string>(input));
     parse_into(*result, path);
     return result;
   }

--- a/single_include/inja/inja.hpp
+++ b/single_include/inja/inja.hpp
@@ -2059,9 +2059,9 @@ public:
                   const FunctionStorage& function_storage)
       : config(parser_config), lexer(lexer_config), template_storage(template_storage), function_storage(function_storage) {}
 
-  Template parse(std::string_view input, std::string_view path) {
-    auto result = Template(static_cast<std::string>(input));
-    parse_into(result, path);
+  std::shared_ptr<Template> parse(std::string_view input, std::string_view path) {
+    auto result = std::make_shared<Template>(static_cast<std::string>(input));
+    parse_into(*result, path);
     return result;
   }
 
@@ -2834,7 +2834,7 @@ public:
 
   Template parse(std::string_view input) {
     Parser parser(parser_config, lexer_config, template_storage, function_storage);
-    return parser.parse(input, input_path);
+    return *parser.parse(input, input_path);
   }
 
   Template parse_template(const std::string& filename) {


### PR DESCRIPTION
The variable `result` was a dangling reference when returning from `Parser::parse` function due to internals of `parse_into`, so we create a `std::unique_ptr` of the template and return that instead.

This is to resolve the static analysis warning generated in our envoy repos:
```log
analyze-build: INFO: In file included from source/extensions/filters/http/transformation/inja_transformer.cc:1:
analyze-build: INFO: In file included from ./source/extensions/filters/http/transformation/inja_transformer.h:17:
analyze-build: INFO: bazel-out/k8-fastbuild/bin/external/inja/_virtual_includes/inja-lib/inja/inja.hpp:2065:5: warning: Address of stack memory associated with local variable 'result' is still referred to by the stack variable 'parser' upon returning to the caller.  This will be a dangling reference [core.StackAddressEscape]
analyze-build: INFO:     return result;
analyze-build: INFO:     ^~~~~~~~~~~~~
```